### PR TITLE
Update wallet metadata schema

### DIFF
--- a/metadata-lib/metadata-lib.cabal
+++ b/metadata-lib/metadata-lib.cabal
@@ -44,6 +44,7 @@ library
                      , monad-logger
                      , mtl
                      , network-uri
+                     , quiet
                      , raw-strings-qq
                      , safe-exceptions
                      , scientific

--- a/metadata-lib/src/Cardano/Metadata/Server.hs
+++ b/metadata-lib/src/Cardano/Metadata/Server.hs
@@ -89,9 +89,9 @@ batchHandler (StoreInterface { storeReadBatch = readBatch }) (BatchRequest subje
 handleErrors :: Either ReadError a -> Handler a
 handleErrors r =
   case r of
-    (Left (NoSubject subj))       -> throwError $ err404 { errBody = "Requested subject '" <> c subj <> "' not found" }
-    (Left (NoProperty subj prop)) -> throwError $ err404 { errBody = "Requested subject '" <> c subj <> "' does not have the property '" <> c (getPropertyName prop) <> "'" }
-    (Right x)                     -> pure x
+    (Left (NoSubject (Subject subj)))       -> throwError $ err404 { errBody = "Requested subject '" <> c subj <> "' not found" }
+    (Left (NoProperty (Subject subj) prop)) -> throwError $ err404 { errBody = "Requested subject '" <> c subj <> "' does not have the property '" <> c (getPropertyName prop) <> "'" }
+    (Right x)                               -> pure x
     
   where
     c :: Text -> BL.ByteString

--- a/metadata-lib/src/Cardano/Metadata/Webhook/Server.hs
+++ b/metadata-lib/src/Cardano/Metadata/Webhook/Server.hs
@@ -31,7 +31,7 @@ import           Servant.GitHub.Webhook       ( GitHubEvent, GitHubSignedReqBody
 import qualified Network.Wreq as Wreq
 import qualified Network.Wai.Handler.Warp as Warp
 
-import           Cardano.Metadata.Server.Types (Subject, Entry', _eSubject)
+import           Cardano.Metadata.Server.Types (Subject(Subject), Entry', _eSubject)
 import           Cardano.Metadata.Webhook.Types 
 import           Cardano.Metadata.Webhook.API
 import           Cardano.Metadata.Store.Types (StoreInterface(..))
@@ -116,4 +116,4 @@ pushHook intf getEntryFromFile _ ev@(PushEvent' (Commit added modified removed) 
       let jsonSuffix = ".json"
       case T.stripSuffix jsonSuffix removedFile of
         Nothing      -> putStrLn $ "Not removing 'removedFile' because it's file extension does not match: '" <> T.unpack jsonSuffix <> "'."
-        Just subject -> delete subject
+        Just subject -> delete (Subject subject)

--- a/metadata-lib/src/Test/Cardano/Metadata/Generators.hs
+++ b/metadata-lib/src/Test/Cardano/Metadata/Generators.hs
@@ -43,7 +43,7 @@ complexType =
   <*> Gen.map (Range.linear 0 20) ((,) <$> key <*> val)
 
 complexKey :: MonadGen m => m ComplexKey
-complexKey = subject
+complexKey = unSubject <$> subject
 
 complexKeyVals :: MonadGen m => m [(ComplexKey, ComplexType)]
 complexKeyVals = Gen.list (Range.linear 0 20) ((,) <$> complexKey <*> complexType)
@@ -71,7 +71,7 @@ propName = Gen.choice [ pure $ PropertyName "description"
                           ]
 
 subject :: MonadGen m => m Subject
-subject = Gen.text (Range.linear 0 128) Gen.unicodeAll
+subject = Subject <$> Gen.text (Range.linear 1 256) Gen.unicodeAll
 
 metadataValue :: MonadGen m => m Text
 metadataValue = Gen.text (Range.linear 0 128) Gen.unicodeAll
@@ -117,7 +117,7 @@ assetLogo = AssetLogo . Encoded . convertToBase Base64 . BS.pack <$> Gen.list (R
 assetUnit :: MonadGen m => m AssetUnit
 assetUnit = AssetUnit
   <$> Gen.text (Range.linear 1 30) Gen.unicodeAll
-  <*> Gen.integral (Range.linear 0 19)
+  <*> Gen.integral (Range.linear 1 19)
 
 entry :: MonadGen m => m Entry
 entry = Entry

--- a/metadata-validator/src/Main.hs
+++ b/metadata-validator/src/Main.hs
@@ -17,7 +17,7 @@ import Data.Function ((&))
 import GHC.Int (Int64)
 import Data.Maybe (fromJust)
 import Data.Void (Void)
-import Data.Char (isHexDigit)
+import Data.Char (isPrint)
 import Data.Text (Text)
 import qualified Data.Vector as Vector
 import qualified GitHub.Data.Name as GitHub
@@ -39,16 +39,16 @@ type Parser = P.Parsec Void Text
 
 pFileNameHex :: Parser Text
 pFileNameHex = do
-  (digits :: Text) <- P.takeWhile1P (Just "hex digit/char") isHexDigit
+  (fileName :: Text) <- P.takeWhile1P (Just "printable Unicode character") isPrint
 
-  let numDigits = T.length digits
-  if numDigits < 56 || numDigits > 64
-    then fail $ "Expected 56-64 hex digits but found " <> show numDigits <> "."
+  let len = T.length fileName
+  if len < 1 || len > 256
+    then fail $ "Expected 1-256 chars but found " <> show len <> "."
     else pure ()
 
   _fileSuffix <- P.string ".json"
   P.eof
-  pure digits
+  pure fileName
 
 main :: IO ()
 main = do

--- a/specifications/wallet/submission-schema.json
+++ b/specifications/wallet/submission-schema.json
@@ -95,7 +95,7 @@
           "properties": {
             "decimals": {
               "type": "integer",
-              "minimum": 0,
+              "minimum": 1,
               "maximum": 19
             },
             "name": {


### PR DESCRIPTION
- Increase the maximum length of subjects to 256.
- Add tests to check the length of subjects.
- Increase minimum number of decimals required to 1.
- Subject previously allowed only hex digits, now it allows any
  printable Unicode character.