### PR TITLE
Allow PR validator to accept PRs with > 1 file

### DIFF
--- a/metadata-validator/README.md
+++ b/metadata-validator/README.md
@@ -1,0 +1,22 @@
+# Metadata validator
+
+A tool that validates PRs against the metadata-registry.
+
+It is run as part of the CI process, to only allow submissions to the
+metadata registry that are well-formed.
+
+## Running
+
+The tool can be run locally with:
+
+```
+$ metadata-validator input-output-hk metadata-registry-testnet 4 --no-auth --debug
+$ metadata-validator --help
+```
+
+## Building
+
+```
+(in root of metadata-server project)
+$ nix-build -A metadata-validator
+```

--- a/metadata-validator/metadata-validator.cabal
+++ b/metadata-validator/metadata-validator.cabal
@@ -13,6 +13,7 @@ executable metadata-validator
   build-depends:       aeson
                      , base
                      , bytestring
+                     , co-log
                      , containers
                      , base64-bytestring
                      , directory
@@ -53,3 +54,4 @@ executable metadata-validator
                         -threaded
 
   other-modules:        Paths_metadata_validator
+                        Config

--- a/metadata-validator/src/Config.hs
+++ b/metadata-validator/src/Config.hs
@@ -5,6 +5,7 @@ import qualified Data.ByteString     as BS
 import Data.Text (Text)
 import qualified GitHub as GitHub
 import qualified GitHub.Data.Name as GitHub
+import qualified Colog
 
 data AuthScheme = NoAuthScheme
                 | OAuthScheme BS.ByteString
@@ -14,6 +15,7 @@ data Opts
          , optRepoOwner   :: Text
          , optRepoName    :: Text
          , optIssueNumber :: Int
+         , optLogSeverity :: Colog.Severity
          }
 
 data Config
@@ -21,11 +23,12 @@ data Config
            , cfgRepoOwner   :: GitHub.Name GitHub.Owner
            , cfgRepoName    :: GitHub.Name GitHub.Repo
            , cfgIssueNumber :: GitHub.IssueNumber
+           , cfgLogSeverity :: Colog.Severity
            }
 
 mkConfig :: Opts -> Config
-mkConfig (Opts auth owner name issue) =
-  Config auth (GitHub.N owner) (GitHub.N name) (GitHub.IssueNumber issue)
+mkConfig (Opts auth owner name issue severity) =
+  Config auth (GitHub.N owner) (GitHub.N name) (GitHub.IssueNumber issue) severity
 
 opts :: ParserInfo Opts
 opts =
@@ -42,6 +45,7 @@ parseOpts = Opts
  <*> strArgument (metavar "REPO_OWNER" <> help "Owner of the GitHub repository")
  <*> strArgument (metavar "REPO_NAME" <> help "Name of the GitHub repository")
  <*> argument auto (metavar "ISSUE_NUMBER" <> help "ID of the GitHub pull request")
+ <*> pLogSeverity
 
 pAuthScheme :: Parser AuthScheme
 pAuthScheme = pOAuthScheme <|> pNoAuthScheme
@@ -49,11 +53,35 @@ pAuthScheme = pOAuthScheme <|> pNoAuthScheme
     pNoAuthScheme =
       flag' NoAuthScheme
         (  long "no-auth"
-        <> help "Don't authenticate with GitHub (beware of rate-limiting on reads)."
+        <> help "Don't authenticate with GitHub (beware of rate-limiting on reads)"
         )
     pOAuthScheme =
-      OAuthScheme <$> 
-        option auto
+      OAuthScheme <$>
+        strOption
           (  long "oauth"
-          <> help "Authenticate using an OAuth token."
+          <> help "Authenticate using an OAuth token"
           )
+
+pLogSeverity :: Parser Colog.Severity
+pLogSeverity = pDebug <|> pInfo <|> pWarning <|> pError <|> pure Colog.Info
+  where
+    pDebug =
+      flag' Colog.Debug
+        (  long "debug"
+        <> help "Print debug, info, warning, and error messages"
+        )
+    pInfo =
+      flag' Colog.Info
+        (  long "info"
+        <> help "Print info, warning, and error messages"
+        )
+    pWarning =
+      flag' Colog.Warning
+        (  long "warning"
+        <> help "Print warning, and error messages"
+        )
+    pError =
+      flag' Colog.Error
+        (  long "error"
+        <> help "Print error messages only"
+        )

--- a/metadata-validator/src/Main.hs
+++ b/metadata-validator/src/Main.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE KindSignatures #-}
@@ -13,8 +15,11 @@ module Main where
 
 import qualified GitHub as GitHub
 import qualified Data.Text as T
+import Prelude hiding (log)
 import Data.Function ((&))
+import Data.Foldable (traverse_)
 import GHC.Int (Int64)
+import System.Exit (exitFailure, exitSuccess)
 import Data.Maybe (fromJust)
 import Data.Void (Void)
 import Data.Char (isPrint)
@@ -31,6 +36,8 @@ import qualified Text.Megaparsec as P
 import qualified Text.Megaparsec.Char as P
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSLC
+import Colog (msgSeverity, pattern E, pattern D, pattern I, LogAction, Message, WithLog, log, usingLoggerT, cmap, fmtMessage, logTextStdout, filterBySeverity)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 
 import Cardano.Metadata.Server.Types (Entry')
 import Config (Config(Config), opts, mkConfig, AuthScheme(NoAuthScheme, OAuthScheme))
@@ -52,69 +59,107 @@ pFileNameHex = do
 
 main :: IO ()
 main = do
-  (Config authScheme repoOwner repoName prNumber)
+  (Config authScheme repoOwner repoName prNumber logSeverity)
     <- mkConfig <$> Opt.execParser opts
 
   let
-    run :: forall req. FromJSON req => GitHub.Request ('GitHub.RO :: GitHub.RW) req -> IO req
-    run =
-      let
-        go = case authScheme of
-          NoAuthScheme      -> GitHub.github'
-          OAuthScheme token -> GitHub.github (GitHub.OAuth token)
-      in
-        (either (error . show) pure =<<) . go
+    action :: MonadIO m => LogAction m Message
+    action = filterBySeverity logSeverity msgSeverity (cmap fmtMessage logTextStdout)
 
-  pr      <- run $ GitHub.pullRequestR repoOwner repoName prNumber
-  prFiles <- run $ GitHub.pullRequestFilesR repoOwner repoName prNumber (GitHub.FetchAtLeast 1)
+  usingLoggerT action $ do
+    pr      <- run' authScheme $ GitHub.pullRequestR repoOwner repoName prNumber
+    log D $ T.pack $ "Retrieved pull request: '" <> show pr <> "'."
+    prFiles <- run' authScheme $ GitHub.pullRequestFilesR repoOwner repoName prNumber (GitHub.FetchAtLeast 1)
+    log D $ T.pack $ "Retrieved pull request files: '" <> show prFiles <> "'."
 
+    let
+      baseBranch   = pr & GitHub.pullRequestBase & GitHub.pullRequestCommitRef
+      changedFiles = pr & GitHub.pullRequestChangedFiles
+
+    if baseBranch /= "master"
+      then do
+        log E $ "Wanted base branch 'master' but got '" <> baseBranch <> "'."
+        exitFailure'
+      else pure ()
+
+    if changedFiles <= 0
+      then do
+        log E $ T.pack $ "Pull request must add or modify at least one file, but it changed " <> show changedFiles <> " files."
+        exitFailure'
+      else pure ()
+
+    log I $ T.pack $ "Validating " <> show changedFiles <> " files."
+    traverse_ (validatePRFile authScheme repoOwner repoName) (Vector.toList prFiles)
+    exitSuccess'
+
+validatePRFile
+  :: (MonadIO m, WithLog env Message m)
+  => AuthScheme
+  -> GitHub.Name GitHub.Owner
+  -> GitHub.Name GitHub.Repo
+  -> GitHub.File
+  -> m ()
+validatePRFile authScheme repoOwner repoName file = do
+  let fileName = GitHub.fileFilename file
+
+  log I $ "Validating file " <> fileName
+  log D $ "File contents: " <> T.pack (show file)
+
+  case P.runParser pFileNameHex (T.unpack fileName) fileName of
+    Left err -> do
+      log E $ T.pack $ "Failed to parse file name, error was: '" <> P.errorBundlePretty err <> "'."
+      liftIO $ exitFailure
+    Right _ ->
+      case GitHub.fileStatus file of
+        "removed"  -> log E "Removing a record is not permitted." >> exitFailure'
+        "renamed"  -> log E "Renaming a record is not permitted." >> exitFailure'
+        "modified" -> log I "Modifying a record..."
+        "added"    -> log I "Adding a record..."
+        x          -> log E ("Unknown status '" <> x <> "' is not permitted.") >> exitFailure'
+
+  blob <- run' authScheme $ GitHub.blobR repoOwner repoName (GitHub.N $ fromJust $ GitHub.fileSha file)
+  log D $ "Received blob for file '" <> fileName <> "': " <> (T.pack $ show blob)
   let
-    baseBranch   = pr & GitHub.pullRequestBase & GitHub.pullRequestCommitRef
-    changedFiles = pr & GitHub.pullRequestChangedFiles
+    content = BSL.fromStrict $ Base64.decodeLenient $ TE.encodeUtf8 $ GitHub.blobContent blob
+    contentLength = BSL.length content
 
-  if baseBranch /= "master"
-    then error $ "Wanted base branch 'master' but got '" <> T.unpack baseBranch <> "'."
-    else pure ()
+  if contentLength > metadataJSONMaxSize
+    then log E ("File size in bytes (" <> (T.pack $ show contentLength) <> ") greater than maximum size of " <> (T.pack $ show metadataJSONMaxSize) <> " bytes.") >> exitFailure'
+    else log I ("Good file size ( " <> (T.pack $ show contentLength) <> " < " <> (T.pack $ show metadataJSONMaxSize) <> " bytes)")
 
-  if changedFiles /= 1
-    then error $ "Pull request may only add or modify one file, but it changed " <> show changedFiles <> " files."
-    else pure ()
-
-  case Vector.toList prFiles of
-    []      -> error $ "No files changed!"
-    file:[] -> do
-      putStrLn $ show file
-      let fileName = GitHub.fileFilename file
-      case P.runParser pFileNameHex (T.unpack fileName) fileName of
-        Left err -> error $ "Failed to parse file name, error was: '" <> P.errorBundlePretty err <> "'."
-        Right _ ->
-          case GitHub.fileStatus file of
-            "removed"  -> error "Removing a record is not permitted."
-            "renamed"  -> error "Renaming a record is not permitted."
-            "modified" -> putStrLn "Modifying a record..."
-            "added"    -> putStrLn "Adding a record..."
-            x          -> error $ "Unknown status '" <> T.unpack x <> "' is not permitted."
-
-      blob <- run $ GitHub.blobR repoOwner repoName (GitHub.N $ fromJust $ GitHub.fileSha file)
-      putStrLn $ show blob
-      let
-        content = BSL.fromStrict $ Base64.decodeLenient $ TE.encodeUtf8 $ GitHub.blobContent blob
-        contentLength = BSL.length content
-
-      if contentLength > metadataJSONMaxSize
-        then error $ "File size in bytes (" <> show contentLength <> ") greater than maximum size of " <> show metadataJSONMaxSize <> " bytes."
-        else putStrLn $ "Good file size ( " <> show contentLength <> " < " <> show metadataJSONMaxSize <> " bytes)"
-
-      case Aeson.eitherDecode content of
-        Left err                   -> error $ "Content '" <> BSLC.unpack content <> "' is not a valid JSON value, decoding error was: '" <> show err <> "'."
-        Right (obj :: Aeson.Value) -> do
-          case Aeson.parseEither Aeson.parseJSON obj of
-            Left err           -> error $ "Failed to decode Metadata entry from JSON value '" <> show obj <> "', error was: '" <> show err <> "'."
-            Right (entry :: Entry') -> do
-              putStrLn $ "PR valid!"
-              putStrLn $ "Decoded entry: " <> show entry
-    _files  -> error $ "Too many files changed!"
+  case Aeson.eitherDecode content of
+    Left err                   -> do
+      log E $ T.pack $ "Content '" <> BSLC.unpack content <> "' is not a valid JSON value, decoding error was: '" <> show err <> "'."
+      exitFailure'
+    Right (obj :: Aeson.Value) -> do
+      case Aeson.parseEither Aeson.parseJSON obj of
+        Left err           -> do
+          log E $ T.pack $ "Failed to decode Metadata entry from JSON value '" <> show obj <> "', error was: '" <> show err <> "'."
+          exitFailure'
+        Right (entry :: Entry') -> do
+          log I "PR valid!"
+          log I $ T.pack $ "Decoded entry: " <> show entry
 
 -- | Maximum size in bytes of a metadata entry.
 metadataJSONMaxSize :: Int64
 metadataJSONMaxSize = 380000
+
+exitFailure' :: MonadIO m => m a
+exitFailure' = liftIO exitFailure
+
+exitSuccess' :: MonadIO m => m a
+exitSuccess' = liftIO exitSuccess
+
+run' :: forall env m req. (WithLog env Message m, MonadIO m, FromJSON req) => AuthScheme -> GitHub.Request ('GitHub.RO :: GitHub.RW) req -> m req
+run' authScheme req = do
+  let
+    go = case authScheme of
+      NoAuthScheme      -> GitHub.github'
+      OAuthScheme token -> GitHub.github (GitHub.OAuth token)
+
+  res <- liftIO $ go req
+  case res of
+    Left err -> do
+      log E $ "GitHub error: '" <> (T.pack $ show err) <> "'."
+      exitFailure'
+    Right x  -> pure x


### PR DESCRIPTION
- Allow PR validator to accept PRs with > 1 file.
- Improve logging in PR validator.
- Make amount logged in PR validator configurable with command line flag.
- Fix issue where OAuth credentials couldn't be parsed from the
  command-line.
- Add README for metadata-validator.