### PR TITLE
Ticker maxLength increase to 5 chars - Propose

### DIFF
--- a/specifications/wallet/submission-schema.json
+++ b/specifications/wallet/submission-schema.json
@@ -63,7 +63,7 @@
       "properties": {
         "value": {
           "type": "string",
-          "maxLength": 4,
+          "maxLength": 5,
           "minLength": 2
         },
         "signatures": {


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-wallet/issues/2541#issuecomment-787004069

Update for the maxLength of the Coin/Asset Ticker to be consistent with the Pool Ticker Format (minLength could be raised too from 2 to 3 chars)