### PR TITLE
Fix subject being compared to filePath, instead of file base name

### DIFF
--- a/metadata-validator/metadata-validator.cabal
+++ b/metadata-validator/metadata-validator.cabal
@@ -19,6 +19,7 @@ executable metadata-validator
                      , co-log
                      , containers
                      , directory
+                     , filepath
                      , github
                      , http-client
                      , http-types


### PR DESCRIPTION
- In the validator, Take the base name of the filepath before
  comparing the subject to the base name, so that the extension and
  any preceeding directories are not included in the comparison.
  - i.e. Compare 'a' == subject instead of 'registry/a.json' ==
    subject.