### PR TITLE
Bump cardano-metadata-submitter

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -101,8 +101,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-metadata-submitter
-  tag: 547760bb556584d753e70d707cecd8be486ce83b
-  --sha256: 0nwsmf1kfcijwmglxg684rmmiz526rhmpf5kzy3lrnvvnnjny1hf
+  tag: fcf1010538fbc9bbc00ef1ed8fa37fa06287af45
+  --sha256: 13mrzr5x2nqc85awljv75xlpfwbdmvcclgyr2ql1cla2gzy6b3a8
 
 source-repository-package
     type: git

--- a/metadata-validator/src/Main.hs
+++ b/metadata-validator/src/Main.hs
@@ -45,7 +45,6 @@ import System.FilePath.Posix (takeBaseName)
 import Cardano.Metadata.GoguenRegistry         ( _goguenRegistryEntry_subject,
                                                  parseRegistryEntry, validateEntry)
 import Cardano.Metadata.Types                  (Subject(Subject))
-import Cardano.Metadata.CurrentSlot            (getCurrentSlot, mainnetSlotParameters)
 
 import           Config                        (AuthScheme (NoAuthScheme, OAuthScheme),
                                                 Config (Config), mkConfig, opts)
@@ -143,8 +142,7 @@ validatePRFile authScheme repoOwner repoName file = do
       log I $ T.pack $ "Successfully decoded entry: " <> show entry
 
       log I $ T.pack "Validating attestation signatures and content..."
-      slotNo <- liftIO $ getCurrentSlot mainnetSlotParameters -- FIXME: Allow for choosing between mainnet/testnet
-      case validateEntry slotNo entry of
+      case validateEntry entry of
         Left err -> do
           log E $ "Failed to decode Metadata entry '" <> T.pack (show entry) <> "', error was: '" <> err <> "'."
           exitFailure'


### PR DESCRIPTION
- Bump cardano-metadata-submitter pin in cabal.project to get
  https://github.com/input-output-hk/cardano-metadata-submitter/pull/15 (i.e.
  ignoring of time constraints in policy validation).