### PR TITLE
 Fix webhook failing to remove entries

### DIFF
--- a/metadata-lib/src/Cardano/Metadata/Server.hs
+++ b/metadata-lib/src/Cardano/Metadata/Server.hs
@@ -10,16 +10,16 @@ module Cardano.Metadata.Server
   , MetadataServerAPI
   ) where
 
-import           Prelude hiding (read)
 import           Control.Exception.Safe        (catchAny)
 import           Control.Monad.IO.Class        (liftIO)
+import qualified Data.Aeson                    as Aeson
 import qualified Data.ByteString.Lazy          as BL
-import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8    as BLC
 import qualified Data.HashMap.Strict           as HM
 import           Data.Text                     (Text)
 import qualified Data.Text.Lazy                as TL
 import qualified Data.Text.Lazy.Encoding       as TLE
+import           Prelude                       hiding (read)
 import           Servant
 
 import           Cardano.Metadata.Server.API

--- a/metadata-lib/src/Cardano/Metadata/Server/Types.hs
+++ b/metadata-lib/src/Cardano/Metadata/Server/Types.hs
@@ -31,8 +31,7 @@ import           Data.Aeson.TH
 import qualified Data.HashMap.Strict           as HM
 import           Text.Casing
 
-import           Cardano.Metadata.Types.Common (PropertyName,
-                                                Subject)
+import           Cardano.Metadata.Types.Common (PropertyName, Subject)
 import qualified Cardano.Metadata.Types.Weakly as Weakly
 
 -- | Represents the content of a batch request to the metadata system.

--- a/metadata-lib/src/Cardano/Metadata/Store/Simple.hs
+++ b/metadata-lib/src/Cardano/Metadata/Store/Simple.hs
@@ -2,11 +2,11 @@
 module Cardano.Metadata.Store.Simple where
 
 import           Control.Concurrent.MVar
-import           Data.Functor                  (void)
-import           Data.Map.Strict               (Map)
-import qualified Data.Map.Strict               as Map
-import           Data.Maybe                    (catMaybes)
-import           Prelude                       hiding (init, read)
+import           Data.Functor                 (void)
+import           Data.Map.Strict              (Map)
+import qualified Data.Map.Strict              as Map
+import           Data.Maybe                   (catMaybes)
+import           Prelude                      hiding (init, read)
 
 import           Cardano.Metadata.Store.Types
 

--- a/metadata-lib/src/Cardano/Metadata/Transform.hs
+++ b/metadata-lib/src/Cardano/Metadata/Transform.hs
@@ -27,7 +27,7 @@ module Cardano.Metadata.Transform
   , apply_
   ) where
 
-import Data.Functor.Identity (Identity, runIdentity)
+import           Data.Functor.Identity             (Identity, runIdentity)
 
 import qualified Cardano.Metadata.Transform.Reader as Impl
 

--- a/metadata-lib/src/Cardano/Metadata/Transform/Reader.hs
+++ b/metadata-lib/src/Cardano/Metadata/Transform/Reader.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DeriveFunctor #-}
 
 module Cardano.Metadata.Transform.Reader
   ( Transform
@@ -10,9 +10,10 @@ module Cardano.Metadata.Transform.Reader
   , withInput
   ) where
 
-import Control.Monad.Reader (ReaderT(ReaderT), runReaderT, withReaderT)
-import Control.Applicative (empty, Alternative, (<|>))
-import Control.Comonad
+import           Control.Applicative  (Alternative, empty, (<|>))
+import           Control.Comonad
+import           Control.Monad.Reader (ReaderT (ReaderT), runReaderT,
+                                       withReaderT)
 
 data Transform r f a = Transform (ReaderT r f a)
 
@@ -32,7 +33,7 @@ instance Alternative f => Alternative (Transform r f) where
   empty = Transform empty
   (Transform f1) <|> (Transform f2) = Transform $ f1 <|> f2
 
-instance (Monoid r, Comonad f) => Comonad (Transform r f) where 
+instance (Monoid r, Comonad f) => Comonad (Transform r f) where
   extract trans = extract $ trans `apply` mempty
 
   duplicate (Transform (ReaderT f)) =

--- a/metadata-lib/src/Cardano/Metadata/Types/Common.hs
+++ b/metadata-lib/src/Cardano/Metadata/Types/Common.hs
@@ -1,24 +1,23 @@
 {-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 module Cardano.Metadata.Types.Common where
 
+import           Cardano.Crypto.DSIGN
+import           Cardano.Crypto.Hash
 import           Control.DeepSeq              (NFData)
-import           Data.Maybe (fromMaybe)
-import           Data.Int (Int64)
-import           Data.Scientific (toBoundedInteger)
 import           Data.Aeson                   (FromJSON, FromJSONKey, ToJSON,
                                                ToJSONKey, (.:), (.:?))
 import qualified Data.Aeson                   as Aeson
@@ -26,25 +25,26 @@ import           Data.Aeson.TH                (deriveJSON)
 import qualified Data.Aeson.Types             as Aeson
 import           Data.ByteArray.Encoding      (Base (Base16, Base64),
                                                convertFromBase, convertToBase)
-import qualified Data.ByteString.Char8 as     BC
-import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Char8        as BC
+import qualified Data.ByteString.Lazy         as BSL
 import           Data.Hashable                (Hashable)
 import qualified Data.HashMap.Strict          as HM
+import           Data.Int                     (Int64)
+import           Data.Maybe                   (fromMaybe)
+import           Data.Scientific              (toBoundedInteger)
 import           Data.String                  (IsString)
 import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import           GHC.Generics                 (Generic)
+import           Numeric.Natural              (Natural)
 import           Quiet                        (Quiet (Quiet))
+import           System.FilePath.Posix        (takeBaseName, takeExtensions)
 import           Text.Casing                  (fromHumps, toCamel)
-import           System.FilePath.Posix (takeBaseName, takeExtensions)
 import           Text.ParserCombinators.ReadP (choice, string)
 import           Text.Read                    (readEither, readPrec)
-import           Numeric.Natural (Natural)
 import qualified Text.Read                    as Read (lift)
 import           Web.HttpApiData              (FromHttpApiData)
-import Cardano.Crypto.DSIGN
-import Cardano.Crypto.Hash
 
 -- | The metadata subject, the on-chain identifier
 newtype Subject = Subject { unSubject :: Text }
@@ -58,7 +58,7 @@ newtype SequenceNumber = SequenceNumber { unSequenceNumber :: Natural }
 
 seqFromIntegral :: Integral n => n -> Maybe SequenceNumber
 seqFromIntegral x | x < 0 = Nothing
-seqFromIntegral x         = Just $ SequenceNumber (fromInteger (toInteger x))
+seqFromIntegral x = Just $ SequenceNumber (fromInteger (toInteger x))
 
 seqFromNatural :: Natural -> SequenceNumber
 seqFromNatural n = SequenceNumber n

--- a/metadata-lib/src/Cardano/Metadata/Types/Weakly.hs
+++ b/metadata-lib/src/Cardano/Metadata/Types/Weakly.hs
@@ -6,8 +6,9 @@ import           Data.Aeson                    (FromJSON, ToJSON, (.:))
 import qualified Data.Aeson                    as Aeson
 import qualified Data.HashMap.Strict           as HM
 
-import           Cardano.Metadata.Types.Common (PropertyName,
-                                                Subject, toPropertyNameList, fromPropertyNameList)
+import           Cardano.Metadata.Types.Common (PropertyName, Subject,
+                                                fromPropertyNameList,
+                                                toPropertyNameList)
 
 
 data Metadata

--- a/metadata-lib/src/Cardano/Metadata/Validation/GitHub.hs
+++ b/metadata-lib/src/Cardano/Metadata/Validation/GitHub.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
 
 module Cardano.Metadata.Validation.GitHub
   (
@@ -34,19 +34,18 @@ module Cardano.Metadata.Validation.GitHub
   ) where
 
 
-import           Colog                         (pattern D, pattern E, pattern I, pattern W,
-                                                Message, WithLog,
-                                                log)
-import Data.String (IsString)
-import Data.Text (Text)
-import Prelude hiding (log)
-import qualified Data.Text as T
-import Control.Monad.Except (MonadError, throwError)
-import Data.Foldable (traverse_)
-import Data.Function ((&))
-import Quiet (Quiet(Quiet))
+import           Colog                (pattern D, pattern E, pattern I, Message,
+                                       pattern W, WithLog, log)
+import           Control.Monad.Except (MonadError, throwError)
+import           Data.Foldable        (traverse_)
+import           Data.Function        ((&))
+import           Data.String          (IsString)
+import           Data.Text            (Text)
+import qualified Data.Text            as T
+import           GHC.Generics         (Generic)
 import qualified GitHub
-import GHC.Generics (Generic)
+import           Prelude              hiding (log)
+import           Quiet                (Quiet (Quiet))
 
 newtype ExpectedBaseBranch = ExpectedBaseBranch Text
   deriving (Generic, Eq, Ord)
@@ -97,7 +96,7 @@ fileStatus = ghFileStatus
 data GitHubPullRequest
   = GitHubPullRequest { ghPRBaseBranch      :: Text
                       , ghPRNumChangedFiles :: Int
-                      } 
+                      }
   deriving (Eq, Show)
 
 prBaseBranch :: GitHubPullRequest -> Text
@@ -133,7 +132,7 @@ gitHubValidationRules
 gitHubValidationRules expectedBaseBranch pr files = do
   log D $ T.pack $ "Validating pull request: '" <> show pr <> "'."
 
-  _ <- validatePR expectedBaseBranch pr 
+  _ <- validatePR expectedBaseBranch pr
 
   log D $ T.pack $ "Validating pull request files: '" <> show files <> "'."
   log I $ T.pack $ "Validating " <> show (pr & prNumChangedFiles) <> " files."

--- a/metadata-lib/src/Cardano/Metadata/Validation/Rules.hs
+++ b/metadata-lib/src/Cardano/Metadata/Validation/Rules.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Metadata.Validation.Rules
@@ -31,34 +31,34 @@ module Cardano.Metadata.Validation.Rules
   , Transform.Transform_
   ) where
 
-import Data.Validation (Validation)
-import Data.List.NonEmpty (NonEmpty)
-import Data.Void (Void, absurd)
-import qualified Data.Text as T
-import qualified Data.Aeson as Aeson
-import qualified Data.Map.Strict as M
-import qualified Data.Map.Merge.Strict as M
-import Data.Foldable (traverse_)
-import Numeric.Natural (Natural)
-import Data.Text (Text)
-import Data.Function ((&))
-import Data.Bool (bool)
+import qualified Data.Aeson                        as Aeson
+import           Data.Bool                         (bool)
+import           Data.Foldable                     (traverse_)
+import           Data.Function                     ((&))
+import           Data.List.NonEmpty                (NonEmpty)
+import qualified Data.Map.Merge.Strict             as M
+import qualified Data.Map.Strict                   as M
+import           Data.Text                         (Text)
+import qualified Data.Text                         as T
+import           Data.Validation                   (Validation)
+import           Data.Void                         (Void, absurd)
+import           Numeric.Natural                   (Natural)
 
-import Cardano.Metadata.Types.Common 
-import Cardano.Metadata.Validation.Types 
-import Cardano.Metadata.Transform
-import qualified Cardano.Metadata.Transform as Transform
+import           Cardano.Metadata.Transform
+import qualified Cardano.Metadata.Transform        as Transform
+import           Cardano.Metadata.Types.Common
+import           Cardano.Metadata.Validation.Types
 
 data ValidationError e = ErrorMetadataFileTooBig Natural Natural
                        -- ^ Size of metadata file in bytes exceeds
                        -- maximum (maximum, actual)
-                       | ErrorMetadataFileNameDoesntMatchSubject Subject Text 
+                       | ErrorMetadataFileNameDoesntMatchSubject Subject Text
                        -- ^ Name of the file does not match the
                        -- subject (subject, fileName). This is a
                        -- requirement because otherwise an attacker
                        -- could submit conflicting entries for an
                        -- existing subject by using a different
-                       -- file name. 
+                       -- file name.
                        | ErrorMetadataPropertySequenceNumberMustBeLarger (AttestedProperty Aeson.Value) (AttestedProperty Aeson.Value) SequenceNumber SequenceNumber
                        -- ^ The value of the property changed but the
                        -- sequence number did not increase (propery
@@ -161,7 +161,7 @@ baseFileNameLengthBounds mini maxi diff =
           if len >= mini && len <= maxi
           then valid
           else invalid $ ErrorMetadataFileBaseNameLengthBounds baseName (mini, maxi) len
-          
+
 
 -- | Ensure that the size (in bytes) of a new metadata entry file does
 -- not exceed the given amount.
@@ -222,7 +222,7 @@ sequenceNumber (Changed oldProp newProp) =
     oldSeqNum = attestedSequenceNumber oldProp
     newSeqNum = attestedSequenceNumber newProp
   in
-    newSeqNum > oldSeqNum 
+    newSeqNum > oldSeqNum
     & bool
       (invalid $ ErrorMetadataPropertySequenceNumberMustBeLarger oldProp newProp oldSeqNum newSeqNum)
       valid
@@ -258,7 +258,7 @@ toAttestedPropertyDiffs (Changed old new) =
   let
     attestedOld = metaAttestedProperties $ fileContents old
     attestedNew = metaAttestedProperties $ fileContents new
-  
+
     -- Properties present in both that have been modified are considered changed
     changed = M.zipWithMaybeMatched (\_key a b -> if a == b then Nothing else Just (Changed a b))
     -- Properties present only in new have been added

--- a/metadata-lib/src/Cardano/Metadata/Validation/Types.hs
+++ b/metadata-lib/src/Cardano/Metadata/Validation/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Cardano.Metadata.Validation.Types
@@ -14,18 +14,20 @@ module Cardano.Metadata.Validation.Types
   , valid
   ) where
 
-import Data.Validation (Validation(Failure))
-import Data.List.NonEmpty (NonEmpty)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import qualified Data.Map.Merge.Strict as M
-import qualified Data.HashMap.Strict as HM
-import qualified Data.Bifunctor as Bifunctor
-import qualified Data.Aeson as Aeson
-import Data.Aeson (ToJSON, FromJSON, (.:))
+import           Data.Aeson                    (FromJSON, ToJSON, (.:))
+import qualified Data.Aeson                    as Aeson
+import qualified Data.Bifunctor                as Bifunctor
+import qualified Data.HashMap.Strict           as HM
+import           Data.List.NonEmpty            (NonEmpty)
+import qualified Data.Map.Merge.Strict         as M
+import           Data.Map.Strict               (Map)
+import qualified Data.Map.Strict               as M
+import           Data.Validation               (Validation (Failure))
 
-import Cardano.Metadata.Transform
-import Cardano.Metadata.Types.Common (Subject, PropertyName, Property, PropertyType(Attested,Verifiable), toPropertyNameList, fromPropertyNameList)
+import           Cardano.Metadata.Transform
+import           Cardano.Metadata.Types.Common (Property, PropertyName, PropertyType (Attested, Verifiable),
+                                                Subject, fromPropertyNameList,
+                                                toPropertyNameList)
 
 data Metadata
   = Metadata { metaSubject              :: Subject
@@ -68,7 +70,7 @@ parseProperties obj =
     properties :: [(PropertyName, Aeson.Value)]
     properties = toPropertyNameList $ HM.toList $ foldr HM.delete obj ["subject"]
 
-    partitioned = 
+    partitioned =
       foldr (\(name, val) (atts,vers) ->
         case Aeson.fromJSON val :: Aeson.Result (Property 'Attested Aeson.Value) of
           Aeson.Success attested -> ((name, attested):atts,             vers)

--- a/metadata-lib/src/Cardano/Metadata/Webhook/Server.hs
+++ b/metadata-lib/src/Cardano/Metadata/Webhook/Server.hs
@@ -13,6 +13,7 @@ import           Data.List.NonEmpty             (NonEmpty)
 import qualified Data.List.NonEmpty             as NE
 import           Data.Text                      (Text)
 import qualified Data.Text                      as T
+import System.FilePath.Posix (takeBaseName)
 import           Network.HTTP.Types             (hAccept, hAuthorization,
                                                  hUserAgent)
 import           Network.HTTP.Types.Status      (ok200)
@@ -102,7 +103,7 @@ pushHook intf getEntryFromFile _ ev@(PushEvent' (Commit added modified removed) 
 
     removeEntry :: StoreInterface Subject Weakly.Metadata -> Text -> IO ()
     removeEntry (StoreInterface { storeDelete = delete }) removedFile = do
-      let jsonSuffix = ".json"
-      case T.stripSuffix jsonSuffix removedFile of
-        Nothing      -> putStrLn $ "Not removing 'removedFile' because it's file extension does not match: '" <> T.unpack jsonSuffix <> "'."
-        Just subject -> delete (Subject subject)
+      let removedFileStr = T.unpack removedFile
+      case takeBaseName removedFileStr of
+        ""      -> putStrLn $ "Not removing '" <> removedFileStr <> "' because it's not a file."
+        subject -> delete (Subject $ T.pack subject)

--- a/metadata-lib/src/Cardano/Metadata/Webhook/Server.hs
+++ b/metadata-lib/src/Cardano/Metadata/Webhook/Server.hs
@@ -13,13 +13,13 @@ import           Data.List.NonEmpty             (NonEmpty)
 import qualified Data.List.NonEmpty             as NE
 import           Data.Text                      (Text)
 import qualified Data.Text                      as T
-import System.FilePath.Posix (takeBaseName)
 import           Network.HTTP.Types             (hAccept, hAuthorization,
                                                  hUserAgent)
 import           Network.HTTP.Types.Status      (ok200)
 import qualified Network.Wreq                   as Wreq
 import           Servant
 import           Servant.GitHub.Webhook         (RepoWebhookEvent (..))
+import           System.FilePath.Posix          (takeBaseName)
 
 import           Cardano.Metadata.Store.Types   (StoreInterface (..))
 import           Cardano.Metadata.Types.Common  (Subject (Subject))

--- a/metadata-lib/src/Test/Cardano/Helpers.hs
+++ b/metadata-lib/src/Test/Cardano/Helpers.hs
@@ -1,16 +1,17 @@
 module Test.Cardano.Helpers where
 
-import           Data.Aeson          (FromJSON, ToJSON)
-import qualified Data.Aeson          as Aeson
-import qualified Data.HashMap.Strict as HM
-import           Data.List           (sort)
-import           Data.Word (Word8)
-import           Data.Text           (Text)
-import           Hedgehog            (Gen, MonadTest, failure, footnote, forAll,
-                                      property, tripping, (===), toGenT, GenT)
-import Hedgehog.Internal.Property (forAllT)
-import qualified Hedgehog            as H (Property)
-import           Text.Read           (readEither)
+import           Data.Aeson                 (FromJSON, ToJSON)
+import qualified Data.Aeson                 as Aeson
+import qualified Data.HashMap.Strict        as HM
+import           Data.List                  (sort)
+import           Data.Text                  (Text)
+import           Data.Word                  (Word8)
+import           Hedgehog                   (Gen, GenT, MonadTest, failure,
+                                             footnote, forAll, property, toGenT,
+                                             tripping, (===))
+import qualified Hedgehog                   as H (Property)
+import           Hedgehog.Internal.Property (forAllT)
+import           Text.Read                  (readEither)
 
 prop_read_show_roundtrips :: (Show a, Eq a, Read a) => Gen a -> H.Property
 prop_read_show_roundtrips gen = property $ do

--- a/metadata-lib/src/Test/Cardano/Metadata/Generators.hs
+++ b/metadata-lib/src/Test/Cardano/Metadata/Generators.hs
@@ -1,45 +1,52 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
 
 module Test.Cardano.Metadata.Generators where
 
+import qualified Cardano.Crypto.DSIGN.Class         as Crypto
+import qualified Cardano.Crypto.DSIGN.Ed25519       as Crypto
+import qualified Cardano.Crypto.Seed                as Crypto
 import           Control.Monad.Except
-import qualified Data.Aeson                    as Aeson
+import           Control.Monad.Morph                (hoist)
+import qualified Data.Aeson                         as Aeson
 import           Data.Aeson.TH
-import qualified Data.HashMap.Strict           as HM
-import           Data.List                     (intersperse)
-import           Data.Int (Int32, Int64)
-import qualified Data.Map.Strict               as M
-import           Data.Text                     (Text)
-import  Data.Functor.Identity (runIdentity)
-import qualified Data.Text                     as T
-import qualified Data.Vector                   as V
+import           Data.Functor.Identity              (runIdentity)
+import qualified Data.HashMap.Strict                as HM
+import           Data.Int                           (Int32, Int64)
+import           Data.List                          (intersperse)
+import qualified Data.Map.Strict                    as M
+import           Data.Text                          (Text)
+import qualified Data.Text                          as T
+import qualified Data.Vector                        as V
 import           Data.Word
-import           Hedgehog                      (Gen, MonadGen, fromGenT, Opaque(Opaque))
-import Control.Monad.Morph (hoist)
-import qualified Hedgehog.Gen                  as Gen
-import qualified Hedgehog.Range                as Range
-import           Network.URI                   (URI (URI), URIAuth (URIAuth))
-import qualified Cardano.Crypto.DSIGN.Class as Crypto
-import qualified Cardano.Crypto.Seed as Crypto
-import qualified Cardano.Crypto.DSIGN.Ed25519 as Crypto
+import           Hedgehog                           (Gen, MonadGen,
+                                                     Opaque (Opaque), fromGenT)
+import qualified Hedgehog.Gen                       as Gen
+import qualified Hedgehog.Range                     as Range
+import           Network.URI                        (URI (URI),
+                                                     URIAuth (URIAuth))
 
-import           Cardano.Metadata.Server.Types (BatchRequest (BatchRequest),
-                                                BatchResponse (BatchResponse))
-import           Cardano.Metadata.Types.Common (File(File), Property, PropertyType(Verifiable), AttestedProperty(AttestedProperty), AnnotatedSignature, SequenceNumber, seqFromNatural,
-                                                Description,
-                                                HashFn (Blake2b224, Blake2b256, SHA256),
-                                                Name, Owner (Owner),
-                                                PreImage (PreImage),
-                                                PropertyName (PropertyName),
-                                                Subject (Subject), unSubject, mkAnnotatedSignature)
-import qualified Cardano.Metadata.Types.Weakly as Weakly
-import qualified Cardano.Metadata.Validation.Types as Validation
-import Cardano.Metadata.Validation.Types (Difference(Added,Changed,Removed))
-import Cardano.Metadata.Transform (Transform, mkTransform)
+import           Cardano.Metadata.Server.Types      (BatchRequest (BatchRequest),
+                                                     BatchResponse (BatchResponse))
+import           Cardano.Metadata.Transform         (Transform, mkTransform)
+import           Cardano.Metadata.Types.Common      (AnnotatedSignature, AttestedProperty (AttestedProperty),
+                                                     Description, File (File),
+                                                     HashFn (Blake2b224, Blake2b256, SHA256),
+                                                     Name, Owner (Owner),
+                                                     PreImage (PreImage),
+                                                     Property,
+                                                     PropertyName (PropertyName),
+                                                     PropertyType (Verifiable),
+                                                     SequenceNumber,
+                                                     Subject (Subject),
+                                                     mkAnnotatedSignature,
+                                                     seqFromNatural, unSubject)
+import qualified Cardano.Metadata.Types.Weakly      as Weakly
 import qualified Cardano.Metadata.Validation.GitHub as GitHub
+import           Cardano.Metadata.Validation.Types  (Difference (Added, Changed, Removed))
+import qualified Cardano.Metadata.Validation.Types  as Validation
 
 data ComplexType = ComplexType { _ctArr :: [Int]
                                , _ctMap :: M.Map Word8 Word8
@@ -161,7 +168,7 @@ uriAuthority = do
   pure $ URIAuth mempty (T.unpack $ "www." <> mid <> end) mempty
 
 liftGen :: MonadGen m => Gen a -> m a
-liftGen = fromGenT . hoist (pure . runIdentity) 
+liftGen = fromGenT . hoist (pure . runIdentity)
 
 batchRequest :: MonadGen m => m BatchRequest
 batchRequest =
@@ -217,13 +224,13 @@ validationMetadataSignedWith skey subj = do
 validationMetadata :: (MonadIO m, MonadGen m) => Subject -> m Validation.Metadata
 validationMetadata subj = do
   skey <- signingKey
-  validationMetadataSignedWith skey subj 
+  validationMetadataSignedWith skey subj
 
 validationMetadata' :: (MonadIO m, MonadGen m) => m Validation.Metadata
 validationMetadata' = do
   skey   <- signingKey
   subj   <- subject
-  validationMetadataSignedWith skey subj 
+  validationMetadataSignedWith skey subj
 
 propertyName :: MonadGen m => m PropertyName
 propertyName = PropertyName <$> Gen.text (Range.linear 1 64) Gen.unicodeAll
@@ -257,7 +264,7 @@ file :: MonadGen m => m a -> m (File a)
 file genA =
   File
     <$> genA
-    <*> Gen.integral (Range.exponential 0 (fromIntegral (maxBound :: Int64))) 
+    <*> Gen.integral (Range.exponential 0 (fromIntegral (maxBound :: Int64)))
     <*> Gen.string (Range.linear 0 64) Gen.unicode
 
 gitHubFileStatus :: MonadGen m => m GitHub.GitHubFileStatus

--- a/metadata-lib/src/Test/Cardano/Metadata/Store.hs
+++ b/metadata-lib/src/Test/Cardano/Metadata/Store.hs
@@ -11,17 +11,18 @@ module Test.Cardano.Metadata.Store
   , testKeyValueComplexTypeImplementation
   ) where
 
-import           Prelude hiding (read)
 import           Control.Monad                    (join)
 import           Data.Functor                     (void)
 import           Data.List                        (sort)
 import qualified Data.Map.Strict                  as M
 import           Data.Maybe                       (catMaybes)
 import           Data.Word
-import           Hedgehog                         (evalIO, forAll, property, (===))
+import           Hedgehog                         (evalIO, forAll, property,
+                                                   (===))
 import qualified Hedgehog                         as H (Property)
 import qualified Hedgehog.Gen                     as Gen
 import qualified Hedgehog.Range                   as Range
+import           Prelude                          hiding (read)
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 

--- a/metadata-lib/test/Main.hs
+++ b/metadata-lib/test/Main.hs
@@ -1,11 +1,11 @@
-import           Test.Tasty                         (defaultMain,
-                                                     testGroup)
+import           Test.Tasty                              (defaultMain,
+                                                          testGroup)
 
 import qualified Test.Cardano.Metadata.Server
 import qualified Test.Cardano.Metadata.Server.Types
 import qualified Test.Cardano.Metadata.Store.Simple
-import qualified Test.Cardano.Metadata.Types
 import qualified Test.Cardano.Metadata.Transform
+import qualified Test.Cardano.Metadata.Types
 import qualified Test.Cardano.Metadata.Validation
 import qualified Test.Cardano.Metadata.Validation.GitHub
 

--- a/metadata-lib/test/Test/Cardano/Metadata/Server.hs
+++ b/metadata-lib/test/Test/Cardano/Metadata/Server.hs
@@ -10,29 +10,32 @@ module Test.Cardano.Metadata.Server
   ( tests
   ) where
 
-import           Data.Aeson                       (ToJSON)
-import qualified Data.Aeson                       as Aeson
-import qualified Data.ByteString.Char8            as BC
-import qualified Data.ByteString.Lazy.Char8       as BLC
+import           Data.Aeson                    (ToJSON)
+import qualified Data.Aeson                    as Aeson
+import qualified Data.ByteString.Char8         as BC
+import qualified Data.ByteString.Lazy.Char8    as BLC
 import           Data.Foldable
-import qualified Data.HashMap.Strict              as HM
-import           Data.String                      (fromString)
-import qualified Data.Text                        as T
-import           Network.HTTP.Types (methodPost, hContentType)
-import           Prelude                          hiding (read)
+import qualified Data.HashMap.Strict           as HM
+import           Data.String                   (fromString)
+import qualified Data.Text                     as T
+import           Network.HTTP.Types            (hContentType, methodPost)
+import           Network.Wai.Test              (SResponse)
+import           Prelude                       hiding (read)
 import           Test.Hspec.Wai
-import           Test.Tasty                       (TestTree)
+import           Test.Tasty                    (TestTree)
 import           Test.Tasty.Hspec
-import           Network.Wai.Test (SResponse)
 
 import           Cardano.Metadata.Server
-import           Cardano.Metadata.Server.Types    (BatchRequest (BatchRequest),
-                                                   BatchResponse (BatchResponse))
-import           Cardano.Metadata.Store.Simple    (simpleStore)
+import           Cardano.Metadata.Server.Types (BatchRequest (BatchRequest),
+                                                BatchResponse (BatchResponse))
+import           Cardano.Metadata.Store.Simple (simpleStore)
 import           Cardano.Metadata.Store.Types
-import           Cardano.Metadata.Types.Common    (AttestedProperty (AttestedProperty),
-                                                   Subject (Subject), unSubject, PreImage(PreImage), HashFn(SHA256), seqZero)
-import qualified Cardano.Metadata.Types.Weakly    as Weakly
+import           Cardano.Metadata.Types.Common (AttestedProperty (AttestedProperty),
+                                                HashFn (SHA256),
+                                                PreImage (PreImage),
+                                                Subject (Subject), seqZero,
+                                                unSubject)
+import qualified Cardano.Metadata.Types.Weakly as Weakly
 
 tests :: IO TestTree
 tests = do

--- a/metadata-lib/test/Test/Cardano/Metadata/Server/Types.hs
+++ b/metadata-lib/test/Test/Cardano/Metadata/Server/Types.hs
@@ -9,11 +9,10 @@ module Test.Cardano.Metadata.Server.Types
 
 import qualified Data.Aeson                       as Aeson
 import qualified Data.HashMap.Strict              as HM
-import qualified Data.Vector as V
+import qualified Data.Vector                      as V
 import           Test.Tasty                       (TestTree, testGroup)
 import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit                 (Assertion,
-                                                   testCase, (@?=))
+import           Test.Tasty.HUnit                 (Assertion, testCase, (@?=))
 import           Text.RawString.QQ
 
 import           Cardano.Metadata.Server.Types
@@ -140,7 +139,7 @@ unit_batch_response_json_spec = do
       , ( Weakly.Metadata
             "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c274d1888c0"
             $ HM.fromList
-                [ ( "description" 
+                [ ( "description"
                   , Aeson.Object $ HM.fromList
                      [ ("value", Aeson.String "rex")
                      , ("signatures", Aeson.Array $ V.fromList

--- a/metadata-lib/test/Test/Cardano/Metadata/Transform.hs
+++ b/metadata-lib/test/Test/Cardano/Metadata/Transform.hs
@@ -2,21 +2,20 @@ module Test.Cardano.Metadata.Transform
   ( tests
   ) where
 
-import Data.Validation (Validation(Success, Failure))
+import           Data.Validation                  (Validation (Failure, Success))
 import           Data.Word
-import           Hedgehog                         (forAll,
-                                                   property, (===), unOpaque)
+import           Hedgehog                         (forAll, property, unOpaque,
+                                                   (===))
 import qualified Hedgehog                         as H (Property)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import qualified Hedgehog.Gen                     as Gen
+import qualified Hedgehog.Range                   as Range
 import           Test.Tasty                       (TestTree, testGroup)
 import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit                 (Assertion,
-                                                   testCase, (@?=))
+import           Test.Tasty.HUnit                 (Assertion, testCase, (@?=))
 
 -- import           Test.Cardano.Helpers             (prop_functor_laws)
 
-import Cardano.Metadata.Transform
+import           Cardano.Metadata.Transform
 import qualified Test.Cardano.Metadata.Generators as Gen
 
 tests :: TestTree
@@ -103,7 +102,7 @@ prop_monad_laws = property $ do
   -- Left identity
   obs (return a >>= k) === obs (k a)
 
-  -- Right identity 
+  -- Right identity
   obs (m >>= return) === obs (m)
 
   -- Associativity

--- a/metadata-lib/test/Test/Cardano/Metadata/Types.hs
+++ b/metadata-lib/test/Test/Cardano/Metadata/Types.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE QuasiQuotes         #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -15,26 +15,25 @@ import qualified Data.ByteString.Lazy.Char8       as BLC
 import qualified Data.HashMap.Strict              as HM
 import qualified Data.Text                        as T
 import qualified Data.Text.Encoding               as T
-import           Hedgehog                         (Gen, 
-                                                   forAll,
-                                                   property, (===))
-import           Hedgehog.Internal.Property       (forAllT)
+import           Hedgehog                         (Gen, forAll, property, (===))
 import qualified Hedgehog                         as H (Property)
+import           Hedgehog.Internal.Property       (forAllT)
 import           Test.Tasty                       (TestTree, testGroup)
 import           Test.Tasty.Hedgehog
-import           Test.Tasty.HUnit                 (Assertion,
-                                                   testCase, (@?=))
+import           Test.Tasty.HUnit                 (Assertion, testCase, (@?=))
+import           Text.RawString.QQ                (r)
 import           Text.Read                        (readEither)
-import Text.RawString.QQ (r)
 
+import           Cardano.Crypto.DSIGN
 import           Test.Cardano.Helpers             (prop_json_only_has_keys,
                                                    prop_json_roundtrips,
                                                    prop_read_show_roundtrips)
 import qualified Test.Cardano.Metadata.Generators as Gen
-import Cardano.Crypto.DSIGN
 
-import           Cardano.Metadata.Types.Common    (AttestedProperty(AttestedProperty), seqZero, HashFn (Blake2b224, Blake2b256, SHA256),
-                                                   asPublicKey, asAttestationSignature,
+import           Cardano.Metadata.Types.Common    (AttestedProperty (AttestedProperty),
+                                                   HashFn (Blake2b224, Blake2b256, SHA256),
+                                                   asAttestationSignature,
+                                                   asPublicKey, seqZero,
                                                    unPropertyName, unSubject)
 import qualified Cardano.Metadata.Types.Weakly    as Weakly
 

--- a/metadata-lib/test/Test/Cardano/Metadata/Validation/GitHub.hs
+++ b/metadata-lib/test/Test/Cardano/Metadata/Validation/GitHub.hs
@@ -1,30 +1,32 @@
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-} 
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Cardano.Metadata.Validation.GitHub
   ( tests
   ) where
 
-import           Data.Foldable (traverse_)
-import           Colog (LoggerT(LoggerT), Message, runLoggerT, usingLoggerT)
-import           Control.Monad.Except (MonadError, throwError, catchError, Except, lift, runExcept)
-import           Hedgehog                         (forAll,
-                                                   property, (===))
-import qualified Hedgehog                         as H (Property)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
-import           Test.Tasty                       (TestTree, testGroup)
+import           Colog                              (LoggerT (LoggerT), Message,
+                                                     runLoggerT, usingLoggerT)
+import           Control.Monad.Except               (Except, MonadError,
+                                                     catchError, lift,
+                                                     runExcept, throwError)
+import           Data.Foldable                      (traverse_)
+import           Hedgehog                           (forAll, property, (===))
+import qualified Hedgehog                           as H (Property)
+import qualified Hedgehog.Gen                       as Gen
+import qualified Hedgehog.Range                     as Range
+import           Test.Tasty                         (TestTree, testGroup)
 import           Test.Tasty.Hedgehog
 
-import qualified Test.Cardano.Metadata.Generators as Gen
+import qualified Test.Cardano.Metadata.Generators   as Gen
 
-import Cardano.Metadata.Validation.GitHub
+import           Cardano.Metadata.Validation.GitHub
 
 tests :: TestTree
 tests = testGroup "GitHub validation tests"

--- a/metadata-validator-github/src/Config.hs
+++ b/metadata-validator-github/src/Config.hs
@@ -1,14 +1,14 @@
 module Config where
 
 import qualified Colog
-import qualified Data.ByteString     as BS
-import           Data.Text           (Text)
-import qualified Data.Text as T
+import qualified Data.ByteString                    as BS
+import           Data.Text                          (Text)
+import qualified Data.Text                          as T
 import qualified GitHub
-import qualified GitHub.Data.Name    as GitHub
+import qualified GitHub.Data.Name                   as GitHub
 import           Options.Applicative
 
-import Cardano.Metadata.Validation.GitHub (ExpectedBaseBranch(ExpectedBaseBranch))
+import           Cardano.Metadata.Validation.GitHub (ExpectedBaseBranch (ExpectedBaseBranch))
 
 data AuthScheme = NoAuthScheme
                 | OAuthScheme BS.ByteString

--- a/metadata-validator-github/src/Main.hs
+++ b/metadata-validator-github/src/Main.hs
@@ -1,31 +1,39 @@
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE InstanceSigs               #-}
+{-# LANGUAGE KindSignatures             #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
 
 module Main where
 
-import Colog
-import Prelude hiding (log)
-import qualified Options.Applicative as Opt
-import Data.Aeson (FromJSON)
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Except (runExceptT, ExceptT, MonadError)
-import Control.Monad.Reader (ReaderT, MonadReader, runReaderT)
-import System.Exit (exitSuccess, exitFailure)
+import           Colog
+import           Control.Monad.Except               (ExceptT, MonadError,
+                                                     runExceptT)
+import           Control.Monad.IO.Class             (MonadIO, liftIO)
+import           Control.Monad.Reader               (MonadReader, ReaderT,
+                                                     runReaderT)
+import           Data.Aeson                         (FromJSON)
+import qualified Data.Text                          as T
+import qualified Data.Vector                        as Vector
 import qualified GitHub
-import qualified Data.Vector as Vector
-import qualified Data.Text as T
+import qualified Options.Applicative                as Opt
+import           Prelude                            hiding (log)
+import           System.Exit                        (exitFailure, exitSuccess)
 
-import Cardano.Metadata.Validation.GitHub (PullRequestValidationError, gitHubValidationRules, prettyPrintPRValidationError, fromGHFile, fromGHPullRequest)
-import Config (Config(Config), AuthScheme(NoAuthScheme, OAuthScheme), opts, mkConfig)
+import           Cardano.Metadata.Validation.GitHub (PullRequestValidationError,
+                                                     fromGHFile,
+                                                     fromGHPullRequest,
+                                                     gitHubValidationRules,
+                                                     prettyPrintPRValidationError)
+import           Config                             (AuthScheme (NoAuthScheme, OAuthScheme),
+                                                     Config (Config), mkConfig,
+                                                     opts)
 
 data Env m = Env { envLogAction  :: !(LogAction m Message) }
 


### PR DESCRIPTION
- The metadata-webhook was failing to remove entries. It determines
the subject to remove by analyzing the deleted files path. The logic
merely stripped the ".json" suffix from the path, but failed to
consider leading directories. As a result, if the file
"mappings/abcdef.json" was removed, it would try to remove
"mappings/abcdef" from the database, which would not work. The logic
now correctly takes the base name of the file, i.e.:

  takeBaseName "/directory/abcdef.ext" == "abcdef"